### PR TITLE
Write slides in jpeg format

### DIFF
--- a/video-presentation.py
+++ b/video-presentation.py
@@ -515,7 +515,7 @@ class VideoMetaData(Extractor):
                         self.logger.debug("Found slide transition at %s", timestamp)
 
                         # Set the path now, but write the image later
-                        slidepath = os.path.join(self.tempdir, 'slide%05d.png' % (len(slides)+1))
+                        slidepath = os.path.join(self.tempdir, 'slide%05d.jpg' % (len(slides)+1))
 
                         slides.append((frame_index, timestamp, slidepath))
 
@@ -548,7 +548,7 @@ class VideoMetaData(Extractor):
             # Grab the image
             _, frame = cap.read()
             # Save the image
-            cv2.imwrite(slide[2], frame, [cv2.IMWRITE_PNG_COMPRESSION, 9])
+            cv2.imwrite(slide[2], frame, [cv2.IMWRITE_JPEG_QUALITY, 90])
         # Add am empty slide to hold the terminating timestamp
         slides.append((frame_index, final_timestamp, None))
         cap.release()


### PR DESCRIPTION
This save 70% image size and has a big impact on the data needed for the previewer. Currently the images for the slides are nearly as large as the video itself!